### PR TITLE
Add trial calculations to discount next

### DIFF
--- a/lib/recurly/pricing/calculations.js
+++ b/lib/recurly/pricing/calculations.js
@@ -190,12 +190,23 @@ Calculations.prototype.discount = function () {
   if (coupon) {
     if (coupon.discount.rate) {
       var discountNow = parseFloat((this.price.now.subtotal * coupon.discount.rate).toFixed(6));
-      var discountNext = coupon.single_use ? 0 : parseFloat((this.price.next.subtotal * coupon.discount.rate).toFixed(6));
+
+      if(this.items.plan.trial && coupon.single_use){
+        var discountNext = parseFloat((this.price.next.subtotal * coupon.discount.rate).toFixed(6));
+      } else {
+        var discountNext = coupon.single_use ? 0 : parseFloat((this.price.next.subtotal * coupon.discount.rate).toFixed(6));
+      }
+
       this.price.now.discount = Math.round(discountNow * 100) / 100;
       this.price.next.discount = Math.round(discountNext * 100) / 100;
     } else {
+
       this.price.now.discount = coupon.discount.amount[this.items.currency];
-      this.price.next.discount = coupon.single_use ? 0 : coupon.discount.amount[this.items.currency];
+      if(this.items.plan.trial && coupon.single_use){
+        this.price.next.discount = coupon.discount.amount[this.items.currency];
+      } else {
+        this.price.next.discount = coupon.single_use ? 0 : coupon.discount.amount[this.items.currency];
+      }
     }
   }
 };


### PR DESCRIPTION
If plan has trial adjust the discount to reflect the next payment for single use coupon codes.  Discount next was not getting updated to reflect the discount to be applied if the plan had a trial period.
